### PR TITLE
Refactor#40/service controller dependency

### DIFF
--- a/backend/memetory/src/main/java/com/example/memetory/domain/member/controller/MemberController.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.memetory.domain.member.dto.MemberServiceDto;
 import com.example.memetory.domain.member.dto.MemberSignUpRequest;
 import com.example.memetory.domain.member.entity.Member;
 import com.example.memetory.domain.member.service.MemberService;
@@ -22,7 +23,9 @@ public class MemberController {
 	@PostMapping("/sign-up")
 	public ResponseEntity<HttpStatus> register(@RequestBody MemberSignUpRequest memberSignUpRequest,
 		@LoginMemberEmail String email) {
-		memberService.register(email, memberSignUpRequest);
+		MemberServiceDto memberServiceDto = memberSignUpRequest.toServiceDto(email);
+
+		memberService.register(memberServiceDto);
 
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}

--- a/backend/memetory/src/main/java/com/example/memetory/domain/member/controller/MemberController.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/member/controller/MemberController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.memetory.domain.member.dto.MemberSignUpRequest;
 import com.example.memetory.domain.member.entity.Member;
 import com.example.memetory.domain.member.service.MemberService;
-import com.example.memetory.global.annotation.LoginMember;
+import com.example.memetory.global.annotation.LoginMemberEmail;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,8 +21,8 @@ public class MemberController {
 
 	@PostMapping("/sign-up")
 	public ResponseEntity<HttpStatus> register(@RequestBody MemberSignUpRequest memberSignUpRequest,
-		@LoginMember Member member) {
-		memberService.register(member, memberSignUpRequest);
+		@LoginMemberEmail String email) {
+		memberService.register(email, memberSignUpRequest);
 
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}

--- a/backend/memetory/src/main/java/com/example/memetory/domain/member/dto/MemberServiceDto.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/member/dto/MemberServiceDto.java
@@ -1,0 +1,14 @@
+package com.example.memetory.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MemberServiceDto {
+	private String email;
+	private String nickname;
+	private String imageUrl;
+}

--- a/backend/memetory/src/main/java/com/example/memetory/domain/member/dto/MemberSignUpRequest.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/member/dto/MemberSignUpRequest.java
@@ -8,4 +8,11 @@ import lombok.NoArgsConstructor;
 @Getter
 public class MemberSignUpRequest {
 	private String nickName;
+
+	public MemberServiceDto toServiceDto(String email) {
+		return MemberServiceDto.builder()
+			.email(email)
+			.nickname(nickName)
+			.build();
+	}
 }

--- a/backend/memetory/src/main/java/com/example/memetory/domain/member/entity/Member.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.example.memetory.domain.member.entity;
 
+import com.example.memetory.domain.member.dto.MemberServiceDto;
 import com.example.memetory.domain.member.dto.MemberSignUpRequest;
 import com.example.memetory.global.entity.BaseEntity;
 
@@ -49,8 +50,8 @@ public class Member extends BaseEntity {
 		this.socialId = socialId;
 	}
 
-	public void register(MemberSignUpRequest memberSignUpRequest) {
-		this.nickname = memberSignUpRequest.getNickName();
+	public void register(MemberServiceDto memberServiceDto) {
+		this.nickname = memberServiceDto.getNickname();
 		this.role = Role.USER;
 	}
 }

--- a/backend/memetory/src/main/java/com/example/memetory/domain/member/service/MemberService.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.example.memetory.domain.member.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.memetory.domain.member.dto.MemberServiceDto;
 import com.example.memetory.domain.member.dto.MemberSignUpRequest;
 import com.example.memetory.domain.member.entity.Member;
 import com.example.memetory.domain.member.exception.NotFoundMemberException;
@@ -29,10 +30,10 @@ public class MemberService {
 	private final HttpServletResponse response;
 
 	@Transactional
-	public void register(String email, MemberSignUpRequest memberSignUpRequest) {
-		Member member = findByEmail(email);
+	public void register(MemberServiceDto memberServiceDto) {
+		Member member = findByEmail(memberServiceDto.getEmail());
 
-		member.register(memberSignUpRequest);
+		member.register(memberServiceDto);
 
 		String refreshToken = jwtService.createRefreshToken();
 

--- a/backend/memetory/src/main/java/com/example/memetory/domain/member/service/MemberService.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/member/service/MemberService.java
@@ -29,7 +29,9 @@ public class MemberService {
 	private final HttpServletResponse response;
 
 	@Transactional
-	public void register(Member member, MemberSignUpRequest memberSignUpRequest) {
+	public void register(String email, MemberSignUpRequest memberSignUpRequest) {
+		Member member = findByEmail(email);
+
 		member.register(memberSignUpRequest);
 
 		String refreshToken = jwtService.createRefreshToken();
@@ -38,13 +40,14 @@ public class MemberService {
 		refreshTokenService.updateToken(member.getEmail(), refreshToken);
 	}
 
-	@Transactional(readOnly = true)
-	public Member getLoginMember() {
+	public String getMemberByEmail() {
 		String accessToken = jwtService.extractAccessToken(request).orElseThrow(NotFoundTokenException::new);
-		String email = jwtService.extractEmail(accessToken).orElseThrow(NotFoundEmailException::new);
-		Member member = memberRepository.findByEmail(email).orElseThrow(NotFoundMemberException::new);
+		return jwtService.extractEmail(accessToken).orElseThrow(NotFoundEmailException::new);
+	}
 
-		return member;
+	@Transactional(readOnly = true)
+	public Member findByEmail(String email) {
+		return memberRepository.findByEmail(email).orElseThrow(NotFoundMemberException::new);
 	}
 
 	@Transactional(readOnly = true)

--- a/backend/memetory/src/main/java/com/example/memetory/domain/meme/controller/MemeController.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/meme/controller/MemeController.java
@@ -20,17 +20,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/meme")
 public class MemeController {
-	private final MemberService memberService;
 	private final MemeService memeService;
 
 	@PostMapping("/create/{id}")
 	public ResponseEntity<HttpStatus> callBackMeme(@PathVariable Long id,
 		@RequestBody ShotStackCallBackRequest shotStackCallBackRequest) {
 
-		Member member = memberService.findById(id);
-		Meme meme = shotStackCallBackRequest.toEntity(member);
-
-		memeService.save(meme);
+		memeService.register(id, shotStackCallBackRequest);
 
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}

--- a/backend/memetory/src/main/java/com/example/memetory/domain/meme/controller/MemeController.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/meme/controller/MemeController.java
@@ -8,10 +8,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.example.memetory.domain.member.entity.Member;
-import com.example.memetory.domain.member.service.MemberService;
+import com.example.memetory.domain.meme.dto.MemeServiceDto;
 import com.example.memetory.domain.meme.dto.ShotStackCallBackRequest;
-import com.example.memetory.domain.meme.entity.Meme;
 import com.example.memetory.domain.meme.service.MemeService;
 
 import lombok.RequiredArgsConstructor;
@@ -26,7 +24,9 @@ public class MemeController {
 	public ResponseEntity<HttpStatus> callBackMeme(@PathVariable Long id,
 		@RequestBody ShotStackCallBackRequest shotStackCallBackRequest) {
 
-		memeService.register(id, shotStackCallBackRequest);
+		MemeServiceDto memeServiceDto = shotStackCallBackRequest.toServiceDto(id);
+
+		memeService.register(memeServiceDto);
 
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}

--- a/backend/memetory/src/main/java/com/example/memetory/domain/meme/dto/MemeServiceDto.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/meme/dto/MemeServiceDto.java
@@ -1,0 +1,13 @@
+package com.example.memetory.domain.meme.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MemeServiceDto {
+	private Long memberId;
+	private String s3Url;
+}

--- a/backend/memetory/src/main/java/com/example/memetory/domain/meme/dto/MemeServiceDto.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/meme/dto/MemeServiceDto.java
@@ -1,5 +1,8 @@
 package com.example.memetory.domain.meme.dto;
 
+import com.example.memetory.domain.member.entity.Member;
+import com.example.memetory.domain.meme.entity.Meme;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,4 +13,11 @@ import lombok.Getter;
 public class MemeServiceDto {
 	private Long memberId;
 	private String s3Url;
+
+	public Meme toEntity(Member member) {
+		return Meme.builder()
+			.member(member)
+			.s3Url(this.s3Url)
+			.build();
+	}
 }

--- a/backend/memetory/src/main/java/com/example/memetory/domain/meme/dto/ShotStackCallBackRequest.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/meme/dto/ShotStackCallBackRequest.java
@@ -1,8 +1,5 @@
 package com.example.memetory.domain.meme.dto;
 
-import com.example.memetory.domain.member.entity.Member;
-import com.example.memetory.domain.meme.entity.Meme;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,10 +11,10 @@ public class ShotStackCallBackRequest {
 	private String url;
 	private String error;
 
-	public Meme toEntity(Member member) {
-		return Meme.builder()
-			.s3Url(this.url)
-			.member(member)
+	public MemeServiceDto toServiceDto(Long memberId) {
+		return MemeServiceDto.builder()
+			.memberId(memberId)
+			.s3Url(url)
 			.build();
 	}
 }

--- a/backend/memetory/src/main/java/com/example/memetory/domain/meme/service/MemeService.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/meme/service/MemeService.java
@@ -3,6 +3,9 @@ package com.example.memetory.domain.meme.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.memetory.domain.member.entity.Member;
+import com.example.memetory.domain.member.service.MemberService;
+import com.example.memetory.domain.meme.dto.ShotStackCallBackRequest;
 import com.example.memetory.domain.meme.entity.Meme;
 import com.example.memetory.domain.meme.repository.MemeRepository;
 
@@ -11,10 +14,14 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class MemeService {
+	private final MemberService memberService;
 	private final MemeRepository memeRepository;
 
 	@Transactional
-	public void save(Meme meme) {
+	public void register(Long id, ShotStackCallBackRequest shotStackCallBackRequest) {
+		Member member = memberService.findById(id);
+		Meme meme = shotStackCallBackRequest.toEntity(member);
+
 		memeRepository.save(meme);
 	}
 }

--- a/backend/memetory/src/main/java/com/example/memetory/domain/meme/service/MemeService.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/meme/service/MemeService.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.memetory.domain.member.entity.Member;
 import com.example.memetory.domain.member.service.MemberService;
+import com.example.memetory.domain.meme.dto.MemeServiceDto;
 import com.example.memetory.domain.meme.dto.ShotStackCallBackRequest;
 import com.example.memetory.domain.meme.entity.Meme;
 import com.example.memetory.domain.meme.repository.MemeRepository;
@@ -18,9 +19,9 @@ public class MemeService {
 	private final MemeRepository memeRepository;
 
 	@Transactional
-	public void register(Long id, ShotStackCallBackRequest shotStackCallBackRequest) {
-		Member member = memberService.findById(id);
-		Meme meme = shotStackCallBackRequest.toEntity(member);
+	public void register(MemeServiceDto memeServiceDto) {
+		Member member = memberService.findById(memeServiceDto.getMemberId());
+		Meme meme = memeServiceDto.toEntity(member);
 
 		memeRepository.save(meme);
 	}

--- a/backend/memetory/src/main/java/com/example/memetory/global/annotation/LoginMemberEmail.java
+++ b/backend/memetory/src/main/java/com/example/memetory/global/annotation/LoginMemberEmail.java
@@ -9,5 +9,5 @@ import java.lang.annotation.Target;
 @Target({ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface LoginMember {
+public @interface LoginMemberEmail {
 }

--- a/backend/memetory/src/main/java/com/example/memetory/global/resolver/LoginMemberArgumentResolver.java
+++ b/backend/memetory/src/main/java/com/example/memetory/global/resolver/LoginMemberArgumentResolver.java
@@ -8,7 +8,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import com.example.memetory.domain.member.service.MemberService;
-import com.example.memetory.global.annotation.LoginMember;
+import com.example.memetory.global.annotation.LoginMemberEmail;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,12 +22,12 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
 
 	@Override
 	public boolean supportsParameter(MethodParameter methodParameter) {
-		return methodParameter.hasParameterAnnotation(LoginMember.class);
+		return methodParameter.hasParameterAnnotation(LoginMemberEmail.class);
 	}
 
 	@Override
 	public Object resolveArgument(MethodParameter methodParameter, ModelAndViewContainer modelAndViewContainer,
 		NativeWebRequest nativeWebRequest, WebDataBinderFactory webDataBinderFactory) {
-		return memberService.getLoginMember();
+		return memberService.getMemberByEmail();
 	}
 }


### PR DESCRIPTION
## Motivation ❄️

- Controller에 노출된 Entity를 수정
- 3-layer-architecture 준수한 코드 작성
- Controller와 Service의 의존성을 낮추기
- 코드의 재활용성 낮추기

<br>

## Key Change 🔑

- Controller와 Service 사이의 ServiceDto를 추가 구현
- 자세한 정리는 Notion/backend/refector 

<br>

## To Reviewers 🙏

- 리뷰어에게 전달할 말

