### PR TITLE
Feat#75/send token through body

### DIFF
--- a/backend/memetory/src/main/java/com/example/memetory/global/security/jwt/dto/TokenResponse.java
+++ b/backend/memetory/src/main/java/com/example/memetory/global/security/jwt/dto/TokenResponse.java
@@ -1,0 +1,19 @@
+package com.example.memetory.global.security.jwt.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TokenResponse {
+	private String accessToken;
+	private String refreshToken;
+
+	@Builder
+	public TokenResponse(String accessToken, String refreshToken) {
+		this.accessToken = accessToken;
+		this.refreshToken = refreshToken;
+	}
+}

--- a/backend/memetory/src/main/java/com/example/memetory/global/security/jwt/dto/TokenResponse.java
+++ b/backend/memetory/src/main/java/com/example/memetory/global/security/jwt/dto/TokenResponse.java
@@ -1,5 +1,6 @@
 package com.example.memetory.global.security.jwt.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema(description = "AccessToken, RefreshToken 반환 포맷")
 public class TokenResponse {
 	private String accessToken;
 	private String refreshToken;

--- a/backend/memetory/src/main/java/com/example/memetory/global/security/jwt/service/JwtService.java
+++ b/backend/memetory/src/main/java/com/example/memetory/global/security/jwt/service/JwtService.java
@@ -1,5 +1,6 @@
 package com.example.memetory.global.security.jwt.service;
 
+import java.io.IOException;
 import java.util.Date;
 import java.util.Optional;
 
@@ -10,9 +11,12 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.example.memetory.domain.member.repository.MemberRepository;
+import com.example.memetory.global.security.jwt.dto.TokenResponse;
 import com.example.memetory.global.security.jwt.exception.NotFoundEmailException;
 import com.example.memetory.global.security.jwt.exception.NotFoundTokenException;
 import com.example.memetory.global.security.jwt.refresh.service.RefreshTokenService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -32,6 +36,7 @@ public class JwtService {
 
 	private final MemberRepository memberRepository;
 	private final RefreshTokenService refreshTokenService;
+	private final ObjectMapper objectMapper;
 
 	@Value("${jwt.secretKey}")
 	private String secretKey;
@@ -45,12 +50,21 @@ public class JwtService {
 	private String refreshHeader;
 
 	public void sendAccessAndRefreshToken(HttpServletResponse response, String email) {
-		setTokenHeader(response, accessHeader, createAccessToken(email));
+		try {
 
 		String refreshToken = createRefreshToken();
-		setTokenHeader(response, refreshHeader, refreshToken);
+		String token = objectMapper.writeValueAsString(TokenResponse.builder()
+			.accessToken(createAccessToken(email))
+			.refreshToken(refreshToken)
+			.build());
+
+		response.getWriter().write(token);
 		refreshTokenService.updateToken(email, refreshToken);
-		log.info("Access Token, Refresh Token 헤더 설정 완료");
+		} catch (IOException e) {
+			// 해당 에러처리 부분에 대해서 고민 필요
+			throw new RuntimeException(e);
+		}
+
 	}
 
 	private String createAccessToken(String email) {
@@ -71,15 +85,11 @@ public class JwtService {
 	}
 
 	public Optional<String> extractRefreshToken(HttpServletRequest request) {
-		return Optional.ofNullable(request.getHeader(refreshHeader))
-			.filter(refreshToken -> refreshToken.startsWith(BEARER))
-			.map(refreshToken -> refreshToken.replace(BEARER, ""));
+		return Optional.ofNullable(request.getHeader(refreshHeader));
 	}
 
 	public Optional<String> extractAccessToken(HttpServletRequest request) {
-		return Optional.ofNullable(request.getHeader(accessHeader))
-			.filter(refreshToken -> refreshToken.startsWith(BEARER))
-			.map(refreshToken -> refreshToken.replace(BEARER, ""));
+		return Optional.ofNullable(request.getHeader(accessHeader));
 	}
 
 	public Optional<String> extractEmail(String accessToken) throws JWTVerificationException {
@@ -95,10 +105,6 @@ public class JwtService {
 	public String getEmail(HttpServletRequest request) {
 		String accessToken = this.extractAccessToken(request).orElseThrow(NotFoundTokenException::new);
 		return this.extractEmail(accessToken).orElseThrow(NotFoundEmailException::new);
-	}
-
-	private void setTokenHeader(HttpServletResponse response, String headerName, String token) {
-		response.setHeader(headerName, BEARER + token);
 	}
 
 	public boolean isTokenValid(String token) {

--- a/backend/memetory/src/main/java/com/example/memetory/global/security/jwt/service/JwtService.java
+++ b/backend/memetory/src/main/java/com/example/memetory/global/security/jwt/service/JwtService.java
@@ -85,11 +85,13 @@ public class JwtService {
 	}
 
 	public Optional<String> extractRefreshToken(HttpServletRequest request) {
-		return Optional.ofNullable(request.getHeader(refreshHeader));
+		return Optional.ofNullable(request.getHeader(refreshHeader))
+			.map(token -> token.replace("Bearer ", ""));
 	}
 
 	public Optional<String> extractAccessToken(HttpServletRequest request) {
-		return Optional.ofNullable(request.getHeader(accessHeader));
+		return Optional.ofNullable(request.getHeader(accessHeader))
+			.map(token -> token.replace("Bearer ", ""));
 	}
 
 	public Optional<String> extractEmail(String accessToken) throws JWTVerificationException {

--- a/backend/memetory/src/test/java/com/example/memetory/domain/auth/AuthTest.java
+++ b/backend/memetory/src/test/java/com/example/memetory/domain/auth/AuthTest.java
@@ -1,6 +1,7 @@
 package com.example.memetory.domain.auth;
 
 import static com.example.memetory.domain.member.MemberFixture.*;
+import static net.bytebuddy.matcher.ElementMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -21,6 +22,7 @@ import com.example.memetory.domain.member.controller.MemberController;
 import com.example.memetory.domain.member.dto.MemberUpdateDto;
 import com.example.memetory.domain.member.service.MemberService;
 import com.example.memetory.global.LoginTest;
+import com.example.memetory.global.security.jwt.dto.TokenResponse;
 import com.example.memetory.global.security.jwt.refresh.domain.RefreshToken;
 
 @DisplayName("JWT 인증테스트의 ")
@@ -36,7 +38,7 @@ public class AuthTest extends LoginTest {
 		// when
 		final ResultActions perform = mockMvc.perform(post("/member").contentType(MediaType.APPLICATION_JSON)
 			.content(toRequestBody(new MemberUpdateDto("junrain2", "imageUrl2")))
-			.header("Authorization", "Bearer " + accessToken));
+			.header("Authorization", accessToken));
 
 		// then
 		perform.andExpect(status().isOk());
@@ -56,7 +58,7 @@ public class AuthTest extends LoginTest {
 		// when
 		final ResultActions perform = mockMvc.perform(post("/member").contentType(MediaType.APPLICATION_JSON)
 			.content(toRequestBody(new MemberUpdateDto("junrain2", "imageUrl2")))
-			.header("Authorization", "Bearer " + accessToken));
+			.header("Authorization", accessToken));
 
 		// then
 		perform.andExpect(status().isForbidden());
@@ -72,19 +74,23 @@ public class AuthTest extends LoginTest {
 			.withExpiresAt(new Date(now.getTime() + 18000))
 			.sign(Algorithm.HMAC512(secretKey));
 
-		RefreshToken token = new RefreshToken(MEMBER().getEmail());
+		TokenResponse expect = TokenResponse.builder()
+			.accessToken(accessToken)
+			.refreshToken(refreshToken)
+			.build();
 
+		RefreshToken token = new RefreshToken(MEMBER().getEmail());
 		given(refreshTokenService.findByToken(refreshToken)).willReturn(token);
 
 		// when
 		final ResultActions perform = mockMvc.perform(post("/member").contentType(MediaType.APPLICATION_JSON)
 			.content(toRequestBody(new MemberUpdateDto("junrain2", "imageUrl2")))
-			.header("Authorization-refresh", "Bearer " + refreshToken)).andDo(print());
+			.header("Authorization-refresh", refreshToken)).andDo(print());
 
 		// then
 		perform.andExpect(status().isForbidden())
-			.andExpect(header().exists("Authorization"))
-			.andExpect(header().exists("Authorization-refresh"));
+			.andExpect(jsonPath("accessToken", is(accessToken)).exists())
+			.andExpect(jsonPath("refreshToken", is(refreshToken)).exists());
 	}
 
 	@Test
@@ -100,7 +106,7 @@ public class AuthTest extends LoginTest {
 		// when
 		final ResultActions perform = mockMvc.perform(post("/member").contentType(MediaType.APPLICATION_JSON)
 			.content(toRequestBody(new MemberUpdateDto("junrain2", "imageUrl2")))
-			.header("Authorization-refresh", "Bearer " + refreshToken)).andDo(print());
+			.header("Authorization-refresh", refreshToken)).andDo(print());
 
 		// then
 		perform.andExpect(status().isForbidden());

--- a/backend/memetory/src/test/java/com/example/memetory/domain/auth/AuthTest.java
+++ b/backend/memetory/src/test/java/com/example/memetory/domain/auth/AuthTest.java
@@ -33,8 +33,20 @@ public class AuthTest extends LoginTest {
 	private MemberService memberService;
 
 	@Test
-	@DisplayName("Access Token을 이용한 정상 로그인")
-	public void accessToken_로그인_성공() throws Exception {
+	@DisplayName("Access Token을 이용한 정상 인가(Bearer)")
+	public void accessToken_인가_성공_with_Bearer() throws Exception {
+		// when
+		final ResultActions perform = mockMvc.perform(post("/member").contentType(MediaType.APPLICATION_JSON)
+			.content(toRequestBody(new MemberUpdateDto("junrain2", "imageUrl2")))
+			.header("Authorization", "Bearer " + accessToken));
+
+		// then
+		perform.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("Access Token을 이용한 정상 인가")
+	public void accessToken_인가_성공() throws Exception {
 		// when
 		final ResultActions perform = mockMvc.perform(post("/member").contentType(MediaType.APPLICATION_JSON)
 			.content(toRequestBody(new MemberUpdateDto("junrain2", "imageUrl2")))


### PR DESCRIPTION
## Motivation ❄️

- 프론트측 요청으로 Token을 헤더에 담아서 보내는 것이 아닌, Json Body를 통해서 보내도록 수정

<br>

## Key Change 🔑

- 기존 Header로 보내던 부분을 Body로 변경해서 전송
- 클라이언트에서 토큰을 보낼 때 "Bearer " 키워드를 선택적으로 작성 가능

<br>

## To Reviewers 🙏

- 리뷰어에게 전달할 말

