### PR TITLE
[Refactor/#114] Redis 기반 실시간 리더보드 정합성 개선 

### DIFF
--- a/backend/memetory/src/main/java/com/example/memetory/domain/like/repository/LikeQueryRepository.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/like/repository/LikeQueryRepository.java
@@ -1,11 +1,22 @@
 package com.example.memetory.domain.like.repository;
 
+import java.time.LocalDate;
+import java.time.Year;
+import java.time.YearMonth;
+import java.util.List;
 import java.util.Optional;
 
 import com.example.memetory.domain.like.entity.Like;
 import com.example.memetory.domain.member.entity.Member;
+import com.example.memetory.domain.memes.dto.MemesRankDto;
 import com.example.memetory.domain.memes.entity.Memes;
 
 public interface LikeQueryRepository {
 	Optional<Like> findLikeByMemberAndMemes(Member member, Memes memes);
+
+	List<MemesRankDto> findDailyRankLimit100(LocalDate localDate);
+
+	List<MemesRankDto> findWeeklyRankLimit100(Year year, int week);
+
+	List<MemesRankDto> findMonthlyRankLimit100(YearMonth yearMonth);
 }

--- a/backend/memetory/src/main/java/com/example/memetory/domain/like/repository/LikeQueryRepositoryImpl.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/like/repository/LikeQueryRepositoryImpl.java
@@ -2,13 +2,22 @@ package com.example.memetory.domain.like.repository;
 
 import static com.example.memetory.domain.like.entity.QLike.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.temporal.WeekFields;
+import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
 import com.example.memetory.domain.like.entity.Like;
 import com.example.memetory.domain.member.entity.Member;
+import com.example.memetory.domain.memes.dto.MemesRankDto;
 import com.example.memetory.domain.memes.entity.Memes;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -20,10 +29,60 @@ public class LikeQueryRepositoryImpl implements LikeQueryRepository {
 
 	@Override
 	public Optional<Like> findLikeByMemberAndMemes(Member member, Memes memes) {
-		return Optional.ofNullable(jpaQueryFactory
-			.selectFrom(like)
-			.where(like.member.eq(member)
-				.and(like.memes.eq(memes)))
-			.fetchFirst());
+		return Optional.ofNullable(
+			jpaQueryFactory.selectFrom(like).where(like.member.eq(member).and(like.memes.eq(memes))).fetchFirst());
 	}
+
+	@Override
+	public List<MemesRankDto> findDailyRankLimit100(LocalDate localDate) {
+		return jpaQueryFactory.select(Projections.constructor(MemesRankDto.class, like.memes.id, like.id.count()))
+			.from(like)
+			.where(like.createdAt.goe(localDate.atStartOfDay()),
+				like.createdAt.lt(localDate.plusDays(1).atStartOfDay()))
+			.groupBy(like.memes)
+			.orderBy(like.id.count().desc())
+			.limit(100L)
+			.fetch();
+	}
+
+	@Override
+	public List<MemesRankDto> findWeeklyRankLimit100(Year year, int week) {
+		// 주차 기준: 한국 (월요일 시작)
+		WeekFields weekFields = WeekFields.of(Locale.KOREA);
+
+		// 해당 주의 시작 날짜 (월요일)
+		LocalDate startOfWeek = year.atDay(1).with(weekFields.weekOfYear(), week).with(weekFields.dayOfWeek(), 1);
+
+		// 다음 주의 시작 날짜 (exclusive)
+		LocalDate endOfWeek = startOfWeek.plusDays(7);
+
+		LocalDateTime startDateTime = startOfWeek.atStartOfDay();     // 월요일 00:00
+		LocalDateTime endDateTime = endOfWeek.atStartOfDay();         // 다음 주 월요일 00:00
+
+		return jpaQueryFactory.select(Projections.constructor(MemesRankDto.class, like.memes.id, like.id.count()))
+			.from(like)
+			.where(like.createdAt.goe(startDateTime), like.createdAt.lt(endDateTime))
+			.groupBy(like.memes.id)
+			.orderBy(like.id.count().desc())
+			.limit(100)
+			.fetch();
+	}
+
+	@Override
+	public List<MemesRankDto> findMonthlyRankLimit100(YearMonth yearMonth) {
+		// 해당 월의 시작일 00:00
+		LocalDateTime startOfMonth = yearMonth.atDay(1).atStartOfDay();
+
+		// 다음 달의 시작일 00:00 (해당 월의 마지막까지 포함되도록)
+		LocalDateTime startOfNextMonth = yearMonth.plusMonths(1).atDay(1).atStartOfDay();
+
+		return jpaQueryFactory.select(Projections.constructor(MemesRankDto.class, like.memes.id, like.id.count()))
+			.from(like)
+			.where(like.createdAt.goe(startOfMonth), like.createdAt.lt(startOfNextMonth))
+			.groupBy(like.memes.id)
+			.orderBy(like.id.count().desc())
+			.limit(100)
+			.fetch();
+	}
+
 }

--- a/backend/memetory/src/main/java/com/example/memetory/domain/like/repository/LikeRepository.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/like/repository/LikeRepository.java
@@ -2,9 +2,12 @@ package com.example.memetory.domain.like.repository;
 
 import com.example.memetory.domain.like.entity.Like;
 import com.example.memetory.domain.member.entity.Member;
+import com.example.memetory.domain.memes.dto.MemesRankDto;
 import com.example.memetory.domain.memes.entity.Memes;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.Year;
+import java.util.List;
 import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like, Long>, LikeQueryRepository {

--- a/backend/memetory/src/main/java/com/example/memetory/domain/like/service/LikeService.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/like/service/LikeService.java
@@ -1,5 +1,6 @@
 package com.example.memetory.domain.like.service;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,8 +13,9 @@ import com.example.memetory.domain.like.repository.LikeRepository;
 import com.example.memetory.domain.member.entity.Member;
 import com.example.memetory.domain.member.service.MemberService;
 import com.example.memetory.domain.memes.entity.Memes;
+import com.example.memetory.domain.memes.event.LikeCreatedEvent;
+import com.example.memetory.domain.memes.event.LikeDeletedEvent;
 import com.example.memetory.domain.memes.service.MemesService;
-import com.example.memetory.domain.memes.service.RankingService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,7 +25,7 @@ public class LikeService {
 	private final MemberService memberService;
 	private final MemesService memesService;
 	private final LikeRepository likeRepository;
-	private final RankingService rankingService;
+	private final ApplicationEventPublisher eventPublisher;
 
 	@Transactional
 	public void registerLike(LikeServiceDto likeServiceDto) {
@@ -32,7 +34,7 @@ public class LikeService {
 
 		Like newLike = Like.fromMemberAndMemes(member, memes);
 		saveLike(newLike);
-		increaseMemesLikeCount(memes);
+		eventPublisher.publishEvent(new LikeCreatedEvent(memes.getId()));
 	}
 
 	private void saveLike(Like like) {
@@ -43,11 +45,6 @@ public class LikeService {
 		}
 	}
 
-	private void increaseMemesLikeCount(Memes memes) {
-		memes.addLikeCount();
-		rankingService.increaseTodayMemesLikeCountFromMemesId(memes.getId());
-	}
-
 	@Transactional
 	public void cancelLike(LikeServiceDto likeServiceDto) {
 		Member member = memberService.findMemberFromEmail(likeServiceDto.getEmail());
@@ -55,11 +52,6 @@ public class LikeService {
 		Like like = likeRepository.findLikeByMemberAndMemes(member, memes).orElseThrow(NotFoundLikeException::new);
 
 		likeRepository.delete(like);
-		decreaseMemesLikeCount(memes);
-	}
-
-	private void decreaseMemesLikeCount(Memes memes) {
-		memes.cancelLikeCount();
-		rankingService.decreaseTodayMemesLikeCountFromMemesId(memes.getId());
+		eventPublisher.publishEvent(new LikeDeletedEvent(memes.getId()));
 	}
 }

--- a/backend/memetory/src/main/java/com/example/memetory/domain/memes/controller/like/MemesLikeApi.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/memes/controller/like/MemesLikeApi.java
@@ -1,5 +1,8 @@
 package com.example.memetory.domain.memes.controller.like;
 
+import java.time.LocalDate;
+import java.time.YearMonth;
+
 import org.springframework.http.ResponseEntity;
 
 import com.example.memetory.global.response.ResultResponse;
@@ -23,7 +26,7 @@ public interface MemesLikeApi {
 			description = "인기차트 조회"
 		)
 	})
-	ResponseEntity<ResultResponse> findTopMemesByLike();
+	ResponseEntity<ResultResponse> findTopMemesByLike(LocalDate date);
 
 	@Operation(
 		summary = "meme`s 이달의 인기차트 조회",
@@ -36,7 +39,7 @@ public interface MemesLikeApi {
 			description = "이달의 인기차트 조회"
 		)
 	})
-	ResponseEntity<ResultResponse> findTopMemesByLikeForMonth();
+	ResponseEntity<ResultResponse> findTopMemesByLikeForMonth(YearMonth yearMonth);
 
 	@Operation(
 		summary = "meme`s 이주의 인기차트 조회",
@@ -49,7 +52,7 @@ public interface MemesLikeApi {
 			description = "이주의 인기차트 조회"
 		)
 	})
-	ResponseEntity<ResultResponse> findTopMemesByLikeForWeek();
+	ResponseEntity<ResultResponse> findTopMemesByLikeForWeek(int year, int week);
 
 	@Operation(
 		summary = "meme`s 좋아요 등록",

--- a/backend/memetory/src/main/java/com/example/memetory/domain/memes/controller/like/MemesLikeController.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/memes/controller/like/MemesLikeController.java
@@ -2,8 +2,12 @@ package com.example.memetory.domain.memes.controller.like;
 
 import static com.example.memetory.global.response.ResultCode.*;
 
+import java.time.LocalDate;
+import java.time.Year;
+import java.time.YearMonth;
 import java.util.List;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -11,6 +15,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.memetory.domain.like.dto.LikeServiceDto;
@@ -29,25 +34,30 @@ public class MemesLikeController implements MemesLikeApi {
 	private final MemesService memesService;
 	private final LikeService likeService;
 
-	@GetMapping("/like/all")
+	@GetMapping("/like/daily")
 	@Override
-	public ResponseEntity<ResultResponse> findTopMemesByLike() {
-		List<MemesInfoResponse> response = memesService.findTopMemesByLike();
+	public ResponseEntity<ResultResponse> findTopMemesByLike(@RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+		List<MemesInfoResponse> response = memesService.findDailyTop10Memes(date);
 		return ResponseEntity.ok(ResultResponse.of(GET_TOP_TEN_MEMES_SUCCESS, response));
-	}
-
-	@GetMapping("/like/month")
-	@Override
-	public ResponseEntity<ResultResponse> findTopMemesByLikeForMonth() {
-		List<MemesInfoResponse> response = memesService.findTopMemesByLikeForMonth();
-		return ResponseEntity.ok(ResultResponse.of(GET_MONTH_TOP_TEN_MEMES_SUCCESS, response));
 	}
 
 	@GetMapping("/like/week")
 	@Override
-	public ResponseEntity<ResultResponse> findTopMemesByLikeForWeek() {
-		List<MemesInfoResponse> response = memesService.findTopMemesByLikeForWeek();
+	public ResponseEntity<ResultResponse> findTopMemesByLikeForWeek(
+		@RequestParam("year") int year,
+		@RequestParam("week") int week
+	) {
+		List<MemesInfoResponse> response = memesService.findWeeklyTop10Memes(Year.of(year), week);
 		return ResponseEntity.ok(ResultResponse.of(GET_WEEK_TOP_TEN_MEMES_SUCCESS, response));
+	}
+
+	@GetMapping("/like/month")
+	@Override
+	public ResponseEntity<ResultResponse> findTopMemesByLikeForMonth(
+		@RequestParam("yearMonth") @DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth
+	) {
+		List<MemesInfoResponse> response = memesService.findMonthlyTop10Memes(yearMonth);
+		return ResponseEntity.ok(ResultResponse.of(GET_MONTH_TOP_TEN_MEMES_SUCCESS, response));
 	}
 
 	@PostMapping("/{memesId}/like")

--- a/backend/memetory/src/main/java/com/example/memetory/domain/memes/event/DailyRankingCreatedEvent.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/memes/event/DailyRankingCreatedEvent.java
@@ -1,0 +1,9 @@
+package com.example.memetory.domain.memes.event;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.example.memetory.domain.memes.dto.MemesRankDto;
+
+public record DailyRankingCreatedEvent(LocalDate date, List<MemesRankDto> memesRank) {
+}

--- a/backend/memetory/src/main/java/com/example/memetory/domain/memes/event/LikeCreatedEvent.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/memes/event/LikeCreatedEvent.java
@@ -1,0 +1,4 @@
+package com.example.memetory.domain.memes.event;
+
+public record LikeCreatedEvent(Long memesId) {
+}

--- a/backend/memetory/src/main/java/com/example/memetory/domain/memes/event/LikeDeletedEvent.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/memes/event/LikeDeletedEvent.java
@@ -1,0 +1,4 @@
+package com.example.memetory.domain.memes.event;
+
+public record LikeDeletedEvent(Long memesId) {
+}

--- a/backend/memetory/src/main/java/com/example/memetory/domain/memes/event/MonthlyRankingCreatedEvent.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/memes/event/MonthlyRankingCreatedEvent.java
@@ -1,0 +1,10 @@
+package com.example.memetory.domain.memes.event;
+
+import java.time.YearMonth;
+import java.util.List;
+
+import com.example.memetory.domain.memes.dto.MemesRankDto;
+
+public record MonthlyRankingCreatedEvent(YearMonth yearMonth, List<MemesRankDto> memesRankDtoList) {
+
+}

--- a/backend/memetory/src/main/java/com/example/memetory/domain/memes/event/RankingEventListener.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/memes/event/RankingEventListener.java
@@ -1,0 +1,39 @@
+package com.example.memetory.domain.memes.event;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.example.memetory.domain.memes.service.RankingService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RankingEventListener {
+	private final RankingService rankingService;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void incrementCount(LikeCreatedEvent event) {
+		try {
+			rankingService.increaseCount(event.memesId());
+		} catch (Exception e) {
+			log.warn("Redis 업데이트 실패 (트랜잭션 커밋 이후): {}", event.memesId(), e);
+		}
+	}
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void decrementCount(LikeDeletedEvent event) {
+		try {
+
+			rankingService.decreaseCount(event.memesId());
+		} catch (Exception e) {
+			log.warn("Redis 업데이트 실패 (트랜잭션 커밋 이후): {}", event.memesId(), e);
+		}
+	}
+}

--- a/backend/memetory/src/main/java/com/example/memetory/domain/memes/event/RankingEventListener.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/memes/event/RankingEventListener.java
@@ -30,10 +30,39 @@ public class RankingEventListener {
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void decrementCount(LikeDeletedEvent event) {
 		try {
-
 			rankingService.decreaseCount(event.memesId());
 		} catch (Exception e) {
 			log.warn("Redis 업데이트 실패 (트랜잭션 커밋 이후): {}", event.memesId(), e);
+		}
+	}
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void createRanking(DailyRankingCreatedEvent event) {
+		try {
+			rankingService.createDailyRanking(event.date(), event.memesRank());
+		} catch (Exception e) {
+			log.warn("Redis 업데이트 실패 (트랜잭션 커밋 이후)");
+		}
+	}
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void createRanking(WeeklyRankingCreatedEvent event) {
+		try {
+			rankingService.createWeeklyRanking(event.year(), event.week(), event.memesRank());
+		} catch (Exception e) {
+			log.warn("Redis 업데이트 실패 (트랜잭션 커밋 이후)");
+		}
+	}
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void createRanking(MonthlyRankingCreatedEvent event) {
+		try {
+			rankingService.createMonthlyRanking(event.yearMonth(), event.memesRankDtoList());
+		} catch (Exception e) {
+			log.warn("Redis 업데이트 실패 (트랜잭션 커밋 이후)");
 		}
 	}
 }

--- a/backend/memetory/src/main/java/com/example/memetory/domain/memes/event/WeeklyRankingCreatedEvent.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/memes/event/WeeklyRankingCreatedEvent.java
@@ -1,0 +1,9 @@
+package com.example.memetory.domain.memes.event;
+
+import java.time.Year;
+import java.util.List;
+
+import com.example.memetory.domain.memes.dto.MemesRankDto;
+
+public record WeeklyRankingCreatedEvent(Year year, int week, List<MemesRankDto> memesRank) {
+}

--- a/backend/memetory/src/main/java/com/example/memetory/domain/memes/repository/MemesRepository.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/memes/repository/MemesRepository.java
@@ -1,8 +1,12 @@
 package com.example.memetory.domain.memes.repository;
 
+import java.util.Collection;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.memetory.domain.memes.entity.Memes;
 
 public interface MemesRepository extends JpaRepository<Memes, Long>, MemesQueryRepository {
+	List<Memes> findMemesByIdIn(Collection<Long> ids);
 }

--- a/backend/memetory/src/main/java/com/example/memetory/domain/memes/service/MemesService.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/memes/service/MemesService.java
@@ -1,14 +1,25 @@
 package com.example.memetory.domain.memes.service;
 
-import static com.example.memetory.global.response.ErrorCode.*;
-
+import java.time.LocalDate;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.temporal.WeekFields;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.memetory.domain.like.repository.LikeRepository;
 import com.example.memetory.domain.member.entity.Member;
 import com.example.memetory.domain.member.service.MemberService;
 import com.example.memetory.domain.meme.entity.Meme;
@@ -19,6 +30,9 @@ import com.example.memetory.domain.memes.dto.response.MemesInfoResponse;
 import com.example.memetory.domain.memes.dto.response.MemesInfoSliceResponse;
 import com.example.memetory.domain.memes.dto.response.MemesResponse;
 import com.example.memetory.domain.memes.entity.Memes;
+import com.example.memetory.domain.memes.event.DailyRankingCreatedEvent;
+import com.example.memetory.domain.memes.event.MonthlyRankingCreatedEvent;
+import com.example.memetory.domain.memes.event.WeeklyRankingCreatedEvent;
 import com.example.memetory.domain.memes.exception.NotFoundMemesException;
 import com.example.memetory.domain.memes.repository.MemesRepository;
 
@@ -31,6 +45,8 @@ public class MemesService {
 	private final MemeService memeService;
 	private final MemesRepository memesRepository;
 	private final RankingService rankingService;
+	private final LikeRepository likeRepository;
+	private final ApplicationEventPublisher eventPublisher;
 
 	@Transactional
 	public MemesResponse registerMemes(MemesServiceDto memesServiceDto) {
@@ -87,32 +103,60 @@ public class MemesService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<MemesInfoResponse> findTopMemesByLike() {
-		return memesRepository.findTopMemesOrderByLikeCount();
+	public List<MemesInfoResponse> findDailyTop10Memes(LocalDate localDate) {
+		return findTop10MemesFromRanking(() -> rankingService.findDailyRanking(localDate),
+			() -> LocalDate.now().equals(localDate), () -> {
+				List<MemesRankDto> dtos = likeRepository.findDailyRankLimit100(localDate);
+				eventPublisher.publishEvent(new DailyRankingCreatedEvent(localDate, dtos));
+				return dtos;
+			});
 	}
 
 	@Transactional(readOnly = true)
-	public List<MemesInfoResponse> findTopMemesByLikeForMonth() {
-		List<MemesRankDto> memesRankDtoList = rankingService.findTopTenMemesLikeCountForMonth();
+	public List<MemesInfoResponse> findWeeklyTop10Memes(Year year, int week) {
+		WeekFields weekFields = WeekFields.of(Locale.KOREA);
+		LocalDate today = LocalDate.now();
 
-		return convertMemesRankDtoListIntoMemesInfoResponseList(memesRankDtoList);
+		return findTop10MemesFromRanking(() -> rankingService.findWeeklyRank(year, week),
+			() -> year.getValue() == today.getYear() && week == today.get(weekFields.weekOfYear()), () -> {
+				List<MemesRankDto> dtos = likeRepository.findWeeklyRankLimit100(year, week);
+				eventPublisher.publishEvent(new WeeklyRankingCreatedEvent(year, week, dtos));
+				return dtos;
+			});
 	}
 
 	@Transactional(readOnly = true)
-	public List<MemesInfoResponse> findTopMemesByLikeForWeek() {
-		List<MemesRankDto> memesRankDtoList = rankingService.findTopTenMemesLikeCountForWeek();
-
-		return convertMemesRankDtoListIntoMemesInfoResponseList(memesRankDtoList);
+	public List<MemesInfoResponse> findMonthlyTop10Memes(YearMonth yearMonth) {
+		return findTop10MemesFromRanking(() -> rankingService.findMonthlyRank(yearMonth),
+			() -> YearMonth.now().equals(yearMonth), () -> {
+				List<MemesRankDto> dtos = likeRepository.findMonthlyRankLimit100(yearMonth);
+				eventPublisher.publishEvent(new MonthlyRankingCreatedEvent(yearMonth, dtos));
+				return dtos;
+			});
 	}
 
-	private List<MemesInfoResponse> convertMemesRankDtoListIntoMemesInfoResponseList(
-		List<MemesRankDto> memesRankDtoList) {
+	private List<MemesInfoResponse> findTop10MemesFromRanking(
+		Supplier<List<MemesRankDto>> cacheSupplier,
+		BooleanSupplier isCurrentPeriodChecker,
+		Supplier<List<MemesRankDto>> dbSupplierWithEvent) {
 
-		return memesRankDtoList.stream().map(this::convertMemesRankDtoInooMemesInfoResponse).toList();
-	}
+		List<MemesRankDto> rankList = cacheSupplier.get();
 
-	private MemesInfoResponse convertMemesRankDtoInooMemesInfoResponse(MemesRankDto memesRank) {
-		Memes memes = findMemesFromMemesId(memesRank.getMemesId());
-		return MemesInfoResponse.fromMemesAndLikeCount(memes, memesRank.getScore());
+		if (rankList.isEmpty()) {
+			if (isCurrentPeriodChecker.getAsBoolean()) {
+				return List.of();
+			}
+			rankList = dbSupplierWithEvent.get();
+		}
+
+		Map<Long, MemesRankDto> rankMap = rankList.stream()
+			.collect(Collectors.toMap(MemesRankDto::getMemesId, Function.identity()));
+
+		List<Memes> memes = memesRepository.findMemesByIdIn(rankMap.keySet());
+
+		return memes.stream().map(m -> {
+			MemesRankDto dto = rankMap.get(m.getId());
+			return MemesInfoResponse.fromMemesAndLikeCount(m, dto.getScore());
+		}).sorted(Comparator.comparing(MemesInfoResponse::getLikeCount).reversed()).limit(10).toList();
 	}
 }

--- a/backend/memetory/src/main/java/com/example/memetory/domain/memes/service/RankingService.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/memes/service/RankingService.java
@@ -2,13 +2,16 @@ package com.example.memetory.domain.memes.service;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.Year;
+import java.time.YearMonth;
 import java.time.temporal.WeekFields;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.DefaultTypedTuple;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
@@ -23,7 +26,7 @@ public class RankingService {
 	private final String PREFIX = "LIKE_RANKING_DATE::";
 	private final String POSTFIX_WEEK = "::WEEK";
 	private final String POSTFIX_MONTH = "::MONTH";
-	private final Long TOP_TEN = 9L;
+	private final Long LIMIT = 99L;
 
 	@Qualifier("rankingRedisTemplate")
 	private final RedisTemplate<String, Long> redisTemplate;
@@ -85,51 +88,66 @@ public class RankingService {
 		return score != null && score > 0;
 	}
 
-	public List<MemesRankDto> findTopTenMemesLikeCountForWeek() {
-		String key = PREFIX + LocalDate.now() + POSTFIX_WEEK;
+	// 그냥 Redis에서 100개의 데이터를 반환
+	public List<MemesRankDto> findDailyRanking(LocalDate localDate) {
+		String key = buildDailyKey(localDate);
 
-		unionMemesIfKeyNotExists(key, 7);
+		Set<ZSetOperations.TypedTuple<Long>> rankTuple = rankingZSet.reverseRangeWithScores(key, 0, LIMIT);
 
-		Set<ZSetOperations.TypedTuple<Long>> rankTuple = rankingZSet.reverseRangeWithScores(key, 0, TOP_TEN);
-		List<MemesRankDto> result = rankTuple.stream().map(MemesRankDto::of).toList();
-
-		return result;
+		return rankTuple.stream().map(MemesRankDto::of).toList();
 	}
 
-	public List<MemesRankDto> findTopTenMemesLikeCountForMonth() {
-		String key = PREFIX + LocalDate.now() + POSTFIX_MONTH;
+	public List<MemesRankDto> findWeeklyRank(Year year, int week) {
+		String key = PREFIX + String.format("%d-%02d", year.getValue(), week) + POSTFIX_WEEK;
 
-		unionMemesIfKeyNotExists(key, 30);
+		Set<ZSetOperations.TypedTuple<Long>> rankTuple = rankingZSet.reverseRangeWithScores(key, 0, LIMIT);
 
-		Set<ZSetOperations.TypedTuple<Long>> rankTuple = rankingZSet.reverseRangeWithScores(key, 0, TOP_TEN);
-		List<MemesRankDto> result = rankTuple.stream().map(MemesRankDto::of).toList();
-
-		return result;
+		return rankTuple.stream().map(MemesRankDto::of).toList();
 	}
 
-	private void unionMemesIfKeyNotExists(String key, int day) {
-		if (isNotExistedKey(key)) {
-			unionMemesFromKeyAndDay(key, day);
-		}
+	public List<MemesRankDto> findMonthlyRank(YearMonth yearMonth) {
+		String key = PREFIX + yearMonth.toString() + POSTFIX_MONTH; // e.g. memes:2024-04:MONTH
+
+		Set<ZSetOperations.TypedTuple<Long>> rankTuple = rankingZSet.reverseRangeWithScores(key, 0, LIMIT);
+
+		return rankTuple.stream()
+			.map(MemesRankDto::of)
+			.toList();
 	}
 
-	private boolean isNotExistedKey(String key) {
-		Set<Long> check = rankingZSet.range(key, 0, 1);
+	public void createDailyRanking(LocalDate date, List<MemesRankDto> rankDtoList) {
+		String key = buildDailyKey(date);
 
-		return check.isEmpty();
+		Set<ZSetOperations.TypedTuple<Long>> tuples = rankDtoList.stream()
+			.map(dto -> new DefaultTypedTuple<>(dto.getMemesId(), (double)dto.getScore()))
+			.collect(Collectors.toSet());
+
+		rankingZSet.add(key, tuples);
+		redisTemplate.expire(key, Duration.ofDays(30));
 	}
 
-	private void unionMemesFromKeyAndDay(String key, int day) {
-		List<String> keyList = new ArrayList<>();
-		LocalDate today = LocalDate.now();
+	public void createWeeklyRanking(Year year, int week, List<MemesRankDto> memesRankDtos) {
+		String key = PREFIX + String.format("%d-%02d", year.getValue(), week) + POSTFIX_WEEK;
 
-		for (int i = 1; i < day; i++) {
-			LocalDate date = today.minusDays(i);
-			keyList.add(PREFIX + date);
-		}
+		Set<ZSetOperations.TypedTuple<Long>> tuples = memesRankDtos.stream()
+			.map(dto -> new DefaultTypedTuple<>(dto.getMemesId(), (double) dto.getScore()))
+			.collect(Collectors.toSet());
 
-		rankingZSet.unionAndStore(key, keyList, key);
+		rankingZSet.add(key, tuples);
+		redisTemplate.expire(key, Duration.ofDays(30));
 	}
+
+	public void createMonthlyRanking(YearMonth yearMonth, List<MemesRankDto> memesRankDtos) {
+		String key = PREFIX + yearMonth.toString() + POSTFIX_MONTH; // e.g. memes:2024-04:MONTH
+
+		Set<ZSetOperations.TypedTuple<Long>> tuples = memesRankDtos.stream()
+			.map(dto -> new DefaultTypedTuple<>(dto.getMemesId(), (double) dto.getScore()))
+			.collect(Collectors.toSet());
+
+		rankingZSet.add(key, tuples);
+		redisTemplate.expire(key, Duration.ofDays(365));
+	}
+
 }
 
 

--- a/backend/memetory/src/main/java/com/example/memetory/domain/memes/service/RankingService.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/memes/service/RankingService.java
@@ -30,57 +30,81 @@ public class RankingService {
 	private final ZSetOperations<String, Long> rankingZSet;
 
 	public void increaseCount(Long memesId) {
-		Duration ttl = Duration.ofDays(1);
-
 		LocalDate now = LocalDate.now();
-		increaseMemesLikeCountForToday(now, memesId, ttl);
-		increaseMemesLikeCountForLastWeek(now, memesId, ttl);
-		increaseMemesLikeCountForLastMonth(now, memesId, ttl);
+
+		increaseWithTtl(buildDailyKey(now), memesId);
+		increaseWithTtl(buildWeeklyKey(now), memesId);
+		increaseWithTtl(buildMonthlyKey(now), memesId);
 	}
 
-	private void increaseMemesLikeCountForToday(LocalDate now, Long memesId, Duration ttl) {
-		String key = PREFIX + now;
-
+	private void increaseWithTtl(String key, Long memesId) {
 		rankingZSet.incrementScore(key, memesId, 1);
-		setExpireIfAbsent(key, ttl);
+		setExpireIfAbsent(key, Duration.ofDays(1));
 	}
 
-	/**
-	 * 주어진 key가 TTL을 가지고 있지 않을 경우 (즉, 새로 생성된 경우),
-	 * 지정된 TTL을 부여한다.
-	 *
-	 * Redis의 TTL 값이 다음 중 하나일 경우 TTL을 설정함:
-	 * - null: TTL 조회 실패 또는 일시적인 연결 문제
-	 * - -1L: 무제한 저장 상태 (TTL이 없음)
-	 */
 	private void setExpireIfAbsent(String key, Duration ttl) {
 		Long expire = redisTemplate.getExpire(key);
 		if (expire == null || expire == -1L) {
 			redisTemplate.expire(key, ttl);
-
 		}
 	}
 
-	private void increaseMemesLikeCountForLastWeek(LocalDate now, Long memesId, Duration ttl) {
-		WeekFields weekFields = WeekFields.of(Locale.KOREA);
-
-		int year = now.getYear();
-		int week = now.get(weekFields.weekOfYear());
-		String key = PREFIX + String.format("%d-%02d", year, week) + POSTFIX_WEEK;
-
-		rankingZSet.incrementScore(key, memesId, 1);
-
-		setExpireIfAbsent(key, ttl);
+	private String buildDailyKey(LocalDate date) {
+		return PREFIX + date;
 	}
 
-	private void increaseMemesLikeCountForLastMonth(LocalDate now, Long memesId, Duration ttl) {
-		int year = now.getYear();
-		int month = now.getMonthValue();
-		String key = PREFIX + String.format("%d-%02d", year, month) + POSTFIX_MONTH;
+	private String buildWeeklyKey(LocalDate date) {
+		WeekFields weekFields = WeekFields.of(Locale.KOREA);
+		int year = date.getYear();
+		int week = date.get(weekFields.weekOfYear());
+		return PREFIX + String.format("%d-%02d", year, week) + POSTFIX_WEEK;
+	}
 
-		rankingZSet.incrementScore(key, memesId, 1);
+	private String buildMonthlyKey(LocalDate date) {
+		int year = date.getYear();
+		int month = date.getMonthValue();
+		return PREFIX + String.format("%d-%02d", year, month) + POSTFIX_MONTH;
+	}
 
-		setExpireIfAbsent(key, ttl);
+	public void decreaseCount(Long memesId) {
+		LocalDate now = LocalDate.now();
+
+		decreaseIfExists(buildDailyKey(now), memesId);
+		decreaseIfExists(buildWeeklyKey(now), memesId);
+		decreaseIfExists(buildMonthlyKey(now), memesId);
+	}
+
+	private void decreaseIfExists(String key, Long memesId) {
+		if (isMemberScored(key, memesId)) {
+			rankingZSet.incrementScore(key, memesId, -1);
+		}
+	}
+
+	private boolean isMemberScored(String key, Long member) {
+		Double score = rankingZSet.score(key, member);
+		return score != null && score > 0;
+	}
+
+	public List<MemesRankDto> findTopTenMemesLikeCountForWeek() {
+		String key = PREFIX + LocalDate.now() + POSTFIX_WEEK;
+
+		unionMemesIfKeyNotExists(key, 7);
+
+		Set<ZSetOperations.TypedTuple<Long>> rankTuple = rankingZSet.reverseRangeWithScores(key, 0, TOP_TEN);
+		List<MemesRankDto> result = rankTuple.stream().map(MemesRankDto::of).toList();
+
+		return result;
+	}
+
+	public List<MemesRankDto> findTopTenMemesLikeCountForMonth() {
+		String key = PREFIX + LocalDate.now() + POSTFIX_MONTH;
+
+		unionMemesIfKeyNotExists(key, 30);
+
+		Set<ZSetOperations.TypedTuple<Long>> rankTuple = rankingZSet.reverseRangeWithScores(key, 0, TOP_TEN);
+		List<MemesRankDto> result = rankTuple.stream().map(MemesRankDto::of).toList();
+
+		return result;
 	}
 
 	private void unionMemesIfKeyNotExists(String key, int day) {
@@ -106,52 +130,6 @@ public class RankingService {
 
 		rankingZSet.unionAndStore(key, keyList, key);
 	}
-
-	public void decreaseCount(Long memesId) {
-		String key = PREFIX + LocalDate.now();
-
-		decreaseMemesLikeCountForToday(key, memesId);
-		decreaseMemesLikeCountForLastWeek(key, memesId);
-		decreaseMemesLikeCountForLastMonth(key, memesId);
-	}
-
-	private void decreaseMemesLikeCountForToday(String key, Long memesId) {
-		rankingZSet.incrementScore(key, memesId, -1);
-	}
-
-	private void decreaseMemesLikeCountForLastWeek(String key, Long memesId) {
-		key += POSTFIX_WEEK;
-
-		unionMemesIfKeyNotExists(key, 7);
-		rankingZSet.incrementScore(key, memesId, -1);
-	}
-
-	private void decreaseMemesLikeCountForLastMonth(String key, Long memesId) {
-		key += POSTFIX_MONTH;
-
-		unionMemesIfKeyNotExists(key, 30);
-		rankingZSet.incrementScore(key, memesId, -1);
-	}
-
-	public List<MemesRankDto> findTopTenMemesLikeCountForWeek() {
-		String key = PREFIX + LocalDate.now() + POSTFIX_WEEK;
-
-		unionMemesIfKeyNotExists(key, 7);
-
-		Set<ZSetOperations.TypedTuple<Long>> rankTuple = rankingZSet.reverseRangeWithScores(key, 0, TOP_TEN);
-		List<MemesRankDto> result = rankTuple.stream().map(MemesRankDto::of).toList();
-
-		return result;
-	}
-
-	public List<MemesRankDto> findTopTenMemesLikeCountForMonth() {
-		String key = PREFIX + LocalDate.now() + POSTFIX_MONTH;
-
-		unionMemesIfKeyNotExists(key, 30);
-
-		Set<ZSetOperations.TypedTuple<Long>> rankTuple = rankingZSet.reverseRangeWithScores(key, 0, TOP_TEN);
-		List<MemesRankDto> result = rankTuple.stream().map(MemesRankDto::of).toList();
-
-		return result;
-	}
 }
+
+

--- a/backend/memetory/src/main/java/com/example/memetory/domain/memes/service/RankingService.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/memes/service/RankingService.java
@@ -1,13 +1,17 @@
 package com.example.memetory.domain.memes.service;
 
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.temporal.WeekFields;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.example.memetory.domain.memes.dto.MemesRankDto;
 
@@ -21,33 +25,62 @@ public class RankingService {
 	private final String POSTFIX_MONTH = "::MONTH";
 	private final Long TOP_TEN = 9L;
 
+	@Qualifier("rankingRedisTemplate")
+	private final RedisTemplate<String, Long> redisTemplate;
 	private final ZSetOperations<String, Long> rankingZSet;
 
-	@Transactional
 	public void increaseCount(Long memesId) {
-		String key = PREFIX + LocalDate.now();
+		Duration ttl = Duration.ofDays(1);
 
-		increaseMemesLikeCountForToday(key, memesId);
-		increaseMemesLikeCountForLastWeek(key, memesId);
-		increaseMemesLikeCountForLastMonth(key, memesId);
+		LocalDate now = LocalDate.now();
+		increaseMemesLikeCountForToday(now, memesId, ttl);
+		increaseMemesLikeCountForLastWeek(now, memesId, ttl);
+		increaseMemesLikeCountForLastMonth(now, memesId, ttl);
 	}
 
-	private void increaseMemesLikeCountForToday(String key, Long memesId) {
+	private void increaseMemesLikeCountForToday(LocalDate now, Long memesId, Duration ttl) {
+		String key = PREFIX + now;
+
 		rankingZSet.incrementScore(key, memesId, 1);
+		setExpireIfAbsent(key, ttl);
 	}
 
-	private void increaseMemesLikeCountForLastWeek(String key, Long memesId) {
-		key += POSTFIX_WEEK;
+	/**
+	 * 주어진 key가 TTL을 가지고 있지 않을 경우 (즉, 새로 생성된 경우),
+	 * 지정된 TTL을 부여한다.
+	 *
+	 * Redis의 TTL 값이 다음 중 하나일 경우 TTL을 설정함:
+	 * - null: TTL 조회 실패 또는 일시적인 연결 문제
+	 * - -1L: 무제한 저장 상태 (TTL이 없음)
+	 */
+	private void setExpireIfAbsent(String key, Duration ttl) {
+		Long expire = redisTemplate.getExpire(key);
+		if (expire == null || expire == -1L) {
+			redisTemplate.expire(key, ttl);
 
-		unionMemesIfKeyNotExists(key, 7);
-		rankingZSet.incrementScore(key, memesId, 1);
+		}
 	}
 
-	private void increaseMemesLikeCountForLastMonth(String key, Long memesId) {
-		key += POSTFIX_MONTH;
+	private void increaseMemesLikeCountForLastWeek(LocalDate now, Long memesId, Duration ttl) {
+		WeekFields weekFields = WeekFields.of(Locale.KOREA);
 
-		unionMemesIfKeyNotExists(key, 30);
+		int year = now.getYear();
+		int week = now.get(weekFields.weekOfYear());
+		String key = PREFIX + String.format("%d-%02d", year, week) + POSTFIX_WEEK;
+
 		rankingZSet.incrementScore(key, memesId, 1);
+
+		setExpireIfAbsent(key, ttl);
+	}
+
+	private void increaseMemesLikeCountForLastMonth(LocalDate now, Long memesId, Duration ttl) {
+		int year = now.getYear();
+		int month = now.getMonthValue();
+		String key = PREFIX + String.format("%d-%02d", year, month) + POSTFIX_MONTH;
+
+		rankingZSet.incrementScore(key, memesId, 1);
+
+		setExpireIfAbsent(key, ttl);
 	}
 
 	private void unionMemesIfKeyNotExists(String key, int day) {
@@ -74,7 +107,6 @@ public class RankingService {
 		rankingZSet.unionAndStore(key, keyList, key);
 	}
 
-	@Transactional
 	public void decreaseCount(Long memesId) {
 		String key = PREFIX + LocalDate.now();
 
@@ -101,7 +133,6 @@ public class RankingService {
 		rankingZSet.incrementScore(key, memesId, -1);
 	}
 
-	@Transactional(readOnly = true)
 	public List<MemesRankDto> findTopTenMemesLikeCountForWeek() {
 		String key = PREFIX + LocalDate.now() + POSTFIX_WEEK;
 
@@ -113,7 +144,6 @@ public class RankingService {
 		return result;
 	}
 
-	@Transactional(readOnly = true)
 	public List<MemesRankDto> findTopTenMemesLikeCountForMonth() {
 		String key = PREFIX + LocalDate.now() + POSTFIX_MONTH;
 

--- a/backend/memetory/src/main/java/com/example/memetory/domain/memes/service/RankingService.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/memes/service/RankingService.java
@@ -24,7 +24,7 @@ public class RankingService {
 	private final ZSetOperations<String, Long> rankingZSet;
 
 	@Transactional
-	public void increaseTodayMemesLikeCountFromMemesId(Long memesId) {
+	public void increaseCount(Long memesId) {
 		String key = PREFIX + LocalDate.now();
 
 		increaseMemesLikeCountForToday(key, memesId);
@@ -75,7 +75,7 @@ public class RankingService {
 	}
 
 	@Transactional
-	public void decreaseTodayMemesLikeCountFromMemesId(Long memesId) {
+	public void decreaseCount(Long memesId) {
 		String key = PREFIX + LocalDate.now();
 
 		decreaseMemesLikeCountForToday(key, memesId);

--- a/backend/memetory/src/main/java/com/example/memetory/domain/voice/controller/VoiceController.java
+++ b/backend/memetory/src/main/java/com/example/memetory/domain/voice/controller/VoiceController.java
@@ -74,29 +74,34 @@ public class VoiceController implements VoiceApi {
                 .block();
     }
 
-    // 멤버별 보이스 조회
-    @GetMapping("/member")
     @Override
-    public ResponseEntity<ResultResponse> findByMemberId(@LoginMemberEmail String email){
-        VoiceServiceDto voiceServiceDto = VoiceServiceDto.create(email);
-        String voiceId = voiceService.findVoiceByMemberId(voiceServiceDto);
-
-        return WebClient
-                .create(getApiUrl + "/" + voiceId)
-                .get()
-                .header("xi-api-key", apiKey)
-                .retrieve()
-                .bodyToMono(ElevenlabsVoiceResponse.class)
-                .flatMap(response -> {
-                    // elevenlabs API 호출이 완료 되면 실행할 로직
-                    return Mono.just(ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_VOICE_SUCCESS, response)));
-                })
-                .onErrorResume(error -> {
-                    System.out.println(("An error occurred while processing the request: {}" + error.getMessage()));
-                    return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build());
-                })
-                .block();
+    public ResponseEntity<ResultResponse> findByMemberId(String email) {
+        return null;
     }
+
+    // // 멤버별 보이스 조회
+    // @GetMapping("/member")
+    // @Override
+    // public ResponseEntity<ResultResponse> findByMemberId(@LoginMemberEmail String email){
+    //     VoiceServiceDto voiceServiceDto = VoiceServiceDto.create(email);
+    //     String voiceId = voiceService.findVoiceByMemberId(voiceServiceDto);
+    //
+    //     return WebClient
+    //             .create(getApiUrl + "/" + voiceId)
+    //             .get()
+    //             .header("xi-api-key", apiKey)
+    //             .retrieve()
+    //             .bodyToMono(Elevenlabs.class)
+    //             .flatMap(response -> {
+    //                 // elevenlabs API 호출이 완료 되면 실행할 로직
+    //                 return Mono.just(ResponseEntity.ok(ResultResponse.of(ResultCode.GET_MEMBER_VOICE_SUCCESS, response)));
+    //             })
+    //             .onErrorResume(error -> {
+    //                 System.out.println(("An error occurred while processing the request: {}" + error.getMessage()));
+    //                 return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build());
+    //             })
+    //             .block();
+    // }
 
     @DeleteMapping("/member")
     @Override

--- a/backend/memetory/src/test/java/com/example/memetory/domain/like/service/LikeServiceTest.java
+++ b/backend/memetory/src/test/java/com/example/memetory/domain/like/service/LikeServiceTest.java
@@ -26,7 +26,6 @@ import com.example.memetory.domain.like.repository.LikeRepository;
 import com.example.memetory.domain.member.entity.Member;
 import com.example.memetory.domain.member.service.MemberService;
 import com.example.memetory.domain.memes.entity.Memes;
-import com.example.memetory.domain.memes.repository.MemesRepository;
 import com.example.memetory.domain.memes.service.MemesService;
 import com.example.memetory.domain.memes.service.RankingService;
 
@@ -67,7 +66,7 @@ public class LikeServiceTest {
 
 		// then
 		assertThat(memes.getLikeCount()).isEqualTo(2L);
-		verify(rankingService).increaseTodayMemesLikeCountFromMemesId(any());
+		verify(rankingService).increaseCount(any());
 		verify(likeRepository).save(any(Like.class));
 	}
 
@@ -100,6 +99,6 @@ public class LikeServiceTest {
 		// then
 		assertThat(memes.getLikeCount()).isZero();
 		verify(likeRepository).delete(like);
-		verify(rankingService).decreaseTodayMemesLikeCountFromMemesId(any());
+		verify(rankingService).decreaseCount(any());
 	}
 }

--- a/backend/memetory/src/test/java/com/example/memetory/domain/memes/service/MemesServiceTest.java
+++ b/backend/memetory/src/test/java/com/example/memetory/domain/memes/service/MemesServiceTest.java
@@ -150,7 +150,7 @@ public class MemesServiceTest {
 	void When_findTopMemesByLikeForWeek_Then_List_MemesInfoResponse() {
 		// given
 		List<MemesRankDto> memesRankDtoList = generateMemesRankDtoList();
-		given(rankingService.findTopTenMemesLikeCountForWeek()).willReturn(memesRankDtoList);
+		given(rankingService.findDailyRanking()).willReturn(memesRankDtoList);
 		given(memesRepository.findByMemesId(any())).willReturn(Optional.ofNullable(MEMES(member, meme)));
 
 		// when

--- a/backend/memetory/src/test/java/com/example/memetory/domain/memes/service/RankingServiceTest.java
+++ b/backend/memetory/src/test/java/com/example/memetory/domain/memes/service/RankingServiceTest.java
@@ -51,7 +51,7 @@ public class RankingServiceTest {
 		Double expectedScore = 1.0;
 
 		// when
-		rankingService.increaseTodayMemesLikeCountFromMemesId(MEMES_ID);
+		rankingService.increaseCount(MEMES_ID);
 
 		// then
 		assertThat(rankingZSet.score(key, MEMES_ID)).isEqualTo(expectedScore);
@@ -66,8 +66,8 @@ public class RankingServiceTest {
 		Double expectedScore = 2.0;
 
 		// when
-		rankingService.increaseTodayMemesLikeCountFromMemesId(MEMES_ID);
-		rankingService.increaseTodayMemesLikeCountFromMemesId(MEMES_ID);
+		rankingService.increaseCount(MEMES_ID);
+		rankingService.increaseCount(MEMES_ID);
 
 		// then
 		assertThat(rankingZSet.score(key, MEMES_ID)).isEqualTo(expectedScore);
@@ -82,7 +82,7 @@ public class RankingServiceTest {
 		Double expectedScore = -1.0;
 
 		// when
-		rankingService.decreaseTodayMemesLikeCountFromMemesId(MEMES_ID);
+		rankingService.decreaseCount(MEMES_ID);
 
 		// then
 		assertThat(rankingZSet.score(key, MEMES_ID)).isEqualTo(expectedScore);

--- a/backend/memetory/src/test/java/com/example/memetory/domain/memes/service/RankingServiceTest.java
+++ b/backend/memetory/src/test/java/com/example/memetory/domain/memes/service/RankingServiceTest.java
@@ -92,7 +92,7 @@ public class RankingServiceTest {
 
 	@Test
 	@DisplayName("존재하지 않는 주간 key를 통한 MemesIdList 반환")
-	void Given_NotExistKey_When_findTopTenMemesLikeCountForWeek_Then_MemesIdList() {
+	void Given_NotExistKey_When_findDailyRankingTenMemesLikeCountForWeek_Then_MemesIdList() {
 		// given
 		for (int i = 0; i < 7; i++) {
 			LocalDate date = LocalDate.now().minusDays(i);
@@ -101,7 +101,7 @@ public class RankingServiceTest {
 		}
 
 		// when
-		List<MemesRankDto> result = rankingService.findTopTenMemesLikeCountForWeek();
+		List<MemesRankDto> result = rankingService.findDailyRanking();
 
 		//then
 		assertThat(result.size()).isEqualTo(6);
@@ -110,7 +110,7 @@ public class RankingServiceTest {
 
 	@Test
 	@DisplayName("존재하는 주간 key를 통한 MemesIdList 반환")
-	void Given_ExistKey_When_findTopTenMemesLikeCountForWeek_Then_MemesIdList() {
+	void Given_ExistKey_When_findDailyRankingTenMemesLikeCountForWeek_Then_MemesIdList() {
 		// given
 		key += POSTFIX_WEEK;
 		rankingZSet.add(key, 7L, 7);
@@ -122,7 +122,7 @@ public class RankingServiceTest {
 		}
 
 		// when
-		List<MemesRankDto> result = rankingService.findTopTenMemesLikeCountForWeek();
+		List<MemesRankDto> result = rankingService.findDailyRanking();
 
 		//then
 		assertThat(result.size()).isEqualTo(1);


### PR DESCRIPTION
## 💡 개요

Redis Sorted Set 기반의 리더보드에서 Redis와 MySQL 간 데이터 정합성을 보다 유연하게 유지하기 위해,  
기존 구조를 Lazy Cache Loading 및 TTL 기반으로 개선하였습니다.

또한 실시간성(즉시성)을 유지하면서도, Redis 장애 또는 캐시 miss 상황에서도 fallback이 가능하도록 구조화했습니다.

---

## ✨ 주요 변경 사항

### 1. Lazy Cache Loading 전략 도입
- Redis에 리더보드 데이터가 없을 경우, DB에서 조회한 후 Redis에 저장
- Redis 조회 시 데이터가 없으면 Redisson 분산 락을 통해 중복 생성 방지
- `TTL` 설정으로 Redis에 저장된 데이터 수명 제어
  - 일간: 30일, 주간: 30일, 월간: 1년

### 2. 좋아요 수 증가/감소 시 Redis Sorted Set에 반영
- 존재하는 키에는 실시간 증가/감소 적용
- 키가 처음 생성되는 경우 TTL 설정을 함께 적용
- Redis score가 없는 경우 무시

### 3. DB → Redis 동기화를 위한 이벤트 기반 구조
- Redis 캐시에 데이터가 없는 경우 DB 통계를 조회하여 `Redis Sorted Set` 생성
- DB 통계 조회 결과는 `@TransactionalEventListener(afterCommit = true)` 방식으로 처리
- 해당 월/주/일이 현재 시점일 경우, Redis에 없더라도 빈 리스트를 반환 (정합성보다 실시간성 우선)

### 4. 삭제된 데이터 필터링
- Redis에서 Top100까지 조회
- DB에 존재하는 데이터만 필터링하여 Top10 응답으로 반환

### 5. 랭킹 API 개선
- `/like/daily?date=2024-04-28`
- `/like/week?year=2024&week=17`
- `/like/month?yearMonth=2024-04`
- 날짜 기반 쿼리 파라미터 도입으로 유연한 API 구성
